### PR TITLE
Linux: Fix kms cube test case.

### DIFF
--- a/os/linux/gbmbufferhandler.cpp
+++ b/os/linux/gbmbufferhandler.cpp
@@ -155,13 +155,14 @@ bool GbmBufferHandler::ImportBuffer(HWCNativeHandle handle, HwcBuffer *bo) {
   memset(bo, 0, sizeof(struct HwcBuffer));
   uint32_t aligned_width = handle->import_data.width;
   uint32_t aligned_height = handle->import_data.height;
+  uint32_t gem_handle = 0;
   bo->format = handle->import_data.format;
-  uint32_t gem_handle = handle->gem_handle;
-  if (!gem_handle && handle->bo) {
-    handle->gem_handle = gbm_bo_get_handle(handle->bo).u32;
+  if (!handle->bo) {
+    handle->bo = gbm_bo_import(device_, GBM_BO_IMPORT_FD, &handle->import_data,
+                               GBM_BO_USE_SCANOUT);
   }
 
-  gem_handle = handle->gem_handle;
+  gem_handle = gbm_bo_get_handle(handle->bo).u32;
 
   if (!gem_handle) {
     ETRACE("Invalid GEM handle. \n");

--- a/os/linux/platformdefines.h
+++ b/os/linux/platformdefines.h
@@ -28,7 +28,6 @@
 struct gbm_handle {
   struct gbm_import_fd_data import_data;
   struct gbm_bo* bo = NULL;
-  uint32_t gem_handle = 0;
 };
 
 typedef struct gbm_handle* HWCNativeHandle;

--- a/tests/kmscube/kmscube.cpp
+++ b/tests/kmscube/kmscube.cpp
@@ -531,7 +531,6 @@ static void init_frames(int32_t width, int32_t height) {
     frame->native_handle.import_data.height = height;
     frame->native_handle.import_data.stride = gbm_bo_get_stride(frame->gbm_bo);
     frame->native_handle.import_data.format = gbm_bo_get_format(frame->gbm_bo);
-    frame->native_handle.gem_handle = gbm_bo_get_handle(frame->gbm_bo).u32;
 
     frame->layer.SetTransform(0);
     frame->layer.SetSourceCrop(hwcomposer::HwcRect<float>(0, 0, width, height));


### PR DESCRIPTION
When creating fbs to scanout buffers ensure they have the right
permissions. The buffer needs to be imported with card0 fd rather
than render node.

Jira: None.
Test: Builds on linux and kms cube demo works correctly.

Signed-off-by: Kalyan Kondapally <kalyan.kondapally@intel.com>