### PR TITLE
Passing proper width height to create Virtual display.

### DIFF
--- a/os/android/drmhwctwo.h
+++ b/os/android/drmhwctwo.h
@@ -123,6 +123,7 @@ class DrmHwcTwo : public hwc2_device_t {
                HWC2::DisplayType type);
     HwcDisplay(const HwcDisplay &) = delete;
     HWC2::Error Init();
+    HWC2::Error Init(uint32_t width, uint32_t height);
 
     HWC2::Error RegisterVsyncCallback(hwc2_callback_data_t data,
                                       hwc2_function_pointer_t func);


### PR DESCRIPTION
Getting proper width and height from CreateVirtualDisplay call and passing
them to InitVirtualDisplay function. This will fix the issue of creating
invalid back buffer.

Jira: https://01.org/jira/browse/AIA-99

Signed-off-by: arpallet <avinash.reddy.palleti@intel.com>